### PR TITLE
Modernize MkDocs deployment workflow and fix environment issue

### DIFF
--- a/.github/workflows/publish-mkdocs.yml
+++ b/.github/workflows/publish-mkdocs.yml
@@ -3,23 +3,32 @@ on:
   push:
     branches:
       - main
+      - dev
       - docs
 
+permissions:
+  contents: write
+
 jobs:
-  build:
-    name: Deploy docs
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          activate-environment: "true"
+          enable-cache: true
+          python-version: 3.13t
+
+      - name: Install dependencies
+        run: uv pip install --python=3.13t -r docs/requirements.txt
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@v2.24.2
-        # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # CUSTOM_DOMAIN: optionaldomain.com
-          CONFIG_FILE: mkdocs.yml
-          EXTRA_PACKAGES: build-base
-          # GITHUB_DOMAIN: github.myenterprise.com
-          REQUIREMENTS: docs/requirements.txt
+        run: mkdocs gh-deploy --force

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material
+mkdocs-material<2
 mkdocs-minify-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,9 +92,6 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.caret
   - pymdownx.details
-  - pymdownx.emoji:
-      emoji_generator: !!python/name:materialx.emoji.to_svg
-      emoji_index: !!python/name:materialx.emoji.twemoji
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ repo_name: NOEL-MNI/noelTexturesPy
 repo_url: https://github.com/NOEL-MNI/noelTexturesPy
 
 # Copyright
-copyright: Copyright &copy; 2023 Neuroimaging of Epilepsy Laboratory
+copyright: Copyright &copy; 2026 Neuroimaging of Epilepsy Laboratory
 
 # Configuration
 theme:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing MkDocs documentation. The workflow has been improved for better security, reliability, and support for multiple branches. The main changes include expanding branch deployment, updating dependencies, and switching to a direct deployment command.

**Workflow improvements:**

* The workflow now triggers on pushes to both the `main` and `dev` branches, in addition to `docs`, allowing documentation to be deployed from more branches.
* Permissions for the workflow are explicitly set to allow writing to repository contents, improving security and clarity.

**Dependency and deployment updates:**

* The workflow now uses `actions/checkout@v7` and installs dependencies with `uv` (via `astral-sh/setup-uv@v8.3.2`), modernizing the environment setup and ensuring dependencies are properly managed.
* The deployment step now uses the direct `mkdocs gh-deploy --force` command instead of the `mhausenblas/mkdocs-deploy-gh-pages` action, simplifying and streamlining the deployment process.
* A step to configure Git credentials for the GitHub Actions bot has been added, which is required for pushing to the `gh-pages` branch.