### PR TITLE
chore(docs): update mkdocs dependencies and ci workflow

### DIFF
--- a/.github/workflows/publish-mkdocs.yml
+++ b/.github/workflows/publish-mkdocs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - dev
       - docs
 
 jobs:
@@ -11,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@v2.24.2
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
         # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-mkdocs-material
+mkdocs>=1.6,<2
+mkdocs-material>=9,<10
 mkdocs-minify-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ repo_name: NOEL-MNI/noelTexturesPy
 repo_url: https://github.com/NOEL-MNI/noelTexturesPy
 
 # Copyright
-copyright: Copyright &copy; 2023 Neuroimaging of Epilepsy Laboratory
+copyright: Copyright &copy; 2026 Neuroimaging of Epilepsy Laboratory
 
 # Configuration
 theme:
@@ -93,8 +93,8 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_generator: !!python/name:materialx.emoji.to_svg
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
- add dev branch trigger to publish-mkdocs workflow
- update actions/checkout to v7 and pin mkdocs-deploy-gh-pages to master
- add version constraints to mkdocs and mkdocs-material dependencies
- fix material.extensions.emoji paths for mkdocs-material 9.x compatibility
- update copyright year to 2026